### PR TITLE
steroids/dev#804 moved prettier functional in backend part

### DIFF
--- a/configs/backend.js
+++ b/configs/backend.js
@@ -1,13 +1,16 @@
 module.exports = {
     "extends": [
         "airbnb-base",
+        "prettier",
         "./common.js"
     ],
+    "plugins": ["prettier"],
     "rules": {
         "@typescript-eslint/no-unused-vars": [
             "warn",
             {"argsIgnorePattern": "^_"}
         ],
+        "prettier/prettier": "error",
     },
     "overrides": [
         {

--- a/configs/common.js
+++ b/configs/common.js
@@ -2,11 +2,10 @@ module.exports = {
     "extends": [
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
-        "prettier"
     ],
     "ignorePatterns": ["eslint*", ".eslint*"],
     "parser": "@typescript-eslint/parser",
-    "plugins": ["@typescript-eslint",  "prettier"],
+    "plugins": ["@typescript-eslint"],
     "env": {
         "node": true,
         "es6": true
@@ -24,7 +23,6 @@ module.exports = {
                 ]
             }
         ],
-        "prettier/prettier": "error",
         "arrow-parens": "off",
         "curly": ["error", "all"],
         "object-curly-spacing": ["error", "never"],

--- a/configs/frontend.js
+++ b/configs/frontend.js
@@ -57,7 +57,8 @@ module.exports = {
     "rules": {
         "react/destructuring-assignment": "off",
         "react/jsx-props-no-spreading": "off",
-        "jsx-quotes": ["off", "prefer-single"],
+        "jsx-quotes": ["warn", "prefer-double"],
+        "quotes": ["warn", "double", { "avoidEscape": true }],
         "react/no-array-index-key": "off",
         "no-alert": "off",
         "react/button-has-type": "off",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steroidsjs/eslint-config",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "",
   "author": "Vladimir Kozhin <hello@kozhindev.com>",
   "exports": {


### PR DESCRIPTION
после обновления eslint-config до 3.0.2

Обнаружил вот такие вот проблемы:

- Сломались (не выдавали ошибки) множество правил, например обязательность ";" в конце строки, обязательное отсутствие пробелов в конце строки и пр. (Это из-за [вот этого](https://github.com/steroids/eslint-config/commit/2fddc9d272c9d0264b31cf95d172a41fe732abd3) PR)
- Ошибка prettier/prettier во всех строках осталась

Эти проблема из-за того, что в boilerplate-nest есть .prettierrc, а у фронта нет, если использовать настройки бека на фронте, то eslint и prettier ругаются друг на друга. Обсудил это с @Novtin , решили, что я вынесу prettier в backend часть steroidsjs/eslint-config. После изменений в текущем PR проблемы фронта уходят, а протестировать на беке у меня нет возможности, но eslint запускается и выполняет проверку без ругательств на конфигурацию